### PR TITLE
make building docs optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ install(
 ## Testing ####################################################################
 ###############################################################################
 
+if(BUILD_TESTING)
 # Directory containing unit test source files
 set(TEST_SRC_BASE "${CMAKE_CURRENT_SOURCE_DIR}/test")
 
@@ -261,6 +262,8 @@ if(MPI_Fortran_FOUND)
     )
     target_compile_options(${TEST_NAME} PUBLIC ${MPI_Fortran_COMPILE_OPTIONS})
 endif()
+
+endif(BUILD_TESTING)
 
 ###############################################################################
 ## Documentation ##############################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ project(zofu
 # Enable MPI support; disabled by default
 option(ENABLE_MPI "Enable MPI" OFF)
 
+option(BUILD_DOCS "build Zofu documentation" OFF)
+
 # Set additional search path for FORD
 set(FORD_PATH "" CACHE PATH "Directory path of FORD documentation tool")
 
@@ -89,7 +91,9 @@ endif()
 include(ZofuAcceptanceHelper)
 
 # Fortran Documenter
-find_package(FORD)
+if(BUILD_DOCS)
+    find_package(FORD)
+endif()
 
 ###############################################################################
 ## Build ######################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,6 @@ endif()
 # CTest setup
 # Needed for valgrind (usually only enable_testing() is needed)
 include(CTest)
-enable_testing()
 
 # Query MPI support
 if(ENABLE_MPI)


### PR DESCRIPTION
I often use Fortran on resource-limited platforms where docs are not necessary. I would like to have the option to avoid building docs even when Ford is present.
For similar reasons, this allows making Zofu self-tests optional (`BUILD_TESTING` is defined TRUE by `include(CTest)`)